### PR TITLE
Deprecate lcd

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,12 @@ Worker also need some basic config:
 
 ```bash
     MANAGERS=0.0.0.0:8085
-    TENDERMINT_RPC_ADDR=https://cosmoshub-3.address
-    DATAHUB_KEY=1QAZXSW23EDCvfr45TGB
-    CHAIN_ID=cosmoshub-3
+    COSMOS_GRPC_ADDR=https://cosmoshub-4.node-address
+    CHAIN_ID=cosmoshub-4
 ```
 
 Where
-    - `TENDERMINT_RPC_ADDR` is a http address to node's RPC endpoint
+    - `COSMOS_GRPC_ADDR` is a http address to a cosmos node's grpc endpoint
     - `MANAGERS` a comma-separated list of manager ip:port addresses that worker will connect to. In this case only one
 
 After running both binaries worker should successfully register itself to the manager.

--- a/api/client.go
+++ b/api/client.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"net/http"
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/client/grpc/tmservice"
@@ -15,7 +14,6 @@ import (
 
 type ClientConfig struct {
 	ReqPerSecond        int
-	ReqPerSecondLCD     int
 	TimeoutBlockCall    time.Duration
 	TimeoutSearchTxCall time.Duration
 }
@@ -34,18 +32,11 @@ type Client struct {
 	bankClient         bankTypes.QueryClient
 
 	cfg *ClientConfig
-
-	// LCD
-	cosmosLCDAddr  string
-	datahubKey     string
-	httpClient     *http.Client
-	rateLimiterLCD *rate.Limiter
 }
 
 // NewClient returns a new client for a given endpoint
-func NewClient(logger *zap.Logger, cli *grpc.ClientConn, cfg *ClientConfig, cosmosLCDAddr, datahubKey string) *Client {
+func NewClient(logger *zap.Logger, cli *grpc.ClientConn, cfg *ClientConfig) *Client {
 	rateLimiterGRPC := rate.NewLimiter(rate.Limit(cfg.ReqPerSecond), cfg.ReqPerSecond)
-	rateLimiterLCD := rate.NewLimiter(rate.Limit(cfg.ReqPerSecondLCD), cfg.ReqPerSecondLCD)
 
 	return &Client{
 		logger:             logger,
@@ -55,13 +46,7 @@ func NewClient(logger *zap.Logger, cli *grpc.ClientConn, cfg *ClientConfig, cosm
 		distributionClient: distributionTypes.NewQueryClient(cli),
 		bankClient:         bankTypes.NewQueryClient(cli),
 		rateLimiterGRPC:    rateLimiterGRPC,
-		cosmosLCDAddr:      cosmosLCDAddr,
-		datahubKey:         datahubKey,
 		cfg:                cfg,
-		rateLimiterLCD:     rateLimiterLCD,
-		httpClient: &http.Client{
-			Timeout: time.Second * 40,
-		},
 	}
 }
 

--- a/cmd/worker-cosmos/config/config.go
+++ b/cmd/worker-cosmos/config/config.go
@@ -27,19 +27,15 @@ type Config struct {
 	Port     string `json:"port" envconfig:"PORT" default:"3000"`
 	HTTPPort string `json:"http_port" envconfig:"HTTP_PORT" default:"8087"`
 
-	DataHubKey string `json:"datahub_key" envconfig:"DATAHUB_KEY"`
-
-	TendermintLCDAddr string `json:"tendermint_lcd_addr" envconfig:"TENDERMINT_LCD_ADDR"`
-	CosmosGRPCAddr    string `json:"cosmos_grpc_addr" envconfig:"COSMOS_GRPC_ADDR"`
-	ChainID           string `json:"chain_id" envconfig:"CHAIN_ID"`
+	CosmosGRPCAddr string `json:"cosmos_grpc_addr" envconfig:"COSMOS_GRPC_ADDR"`
+	ChainID        string `json:"chain_id" envconfig:"CHAIN_ID"`
 
 	Managers        string        `json:"managers" envconfig:"MANAGERS" default:"127.0.0.1:8085"`
 	ManagerInterval time.Duration `json:"manager_interval" envconfig:"MANAGER_INTERVAL" default:"10s"`
 	Hostname        string        `json:"hostname" envconfig:"HOSTNAME"`
 
-	MaximumHeightsToGet  float64 `json:"maximum_heights_to_get" envconfig:"MAXIMUM_HEIGHTS_TO_GET" default:"10000"`
-	RequestsPerSecond    int64   `json:"requests_per_second" envconfig:"REQUESTS_PER_SECOND" default:"33"`
-	RequestsPerSecondLCD int64   `json:"requests_per_second_lcd" envconfig:"REQUESTS_PER_SECOND_LCD" default:"33"`
+	MaximumHeightsToGet float64 `json:"maximum_heights_to_get" envconfig:"MAXIMUM_HEIGHTS_TO_GET" default:"10000"`
+	RequestsPerSecond   int64   `json:"requests_per_second" envconfig:"REQUESTS_PER_SECOND" default:"33"`
 
 	// Rollbar
 	RollbarAccessToken string `json:"rollbar_access_token" envconfig:"ROLLBAR_ACCESS_TOKEN"`

--- a/cmd/worker-cosmos/main.go
+++ b/cmd/worker-cosmos/main.go
@@ -116,17 +116,11 @@ func main() {
 	}
 	defer grpcConn.Close()
 
-	if cfg.TendermintLCDAddr == "" {
-		logger.Error(fmt.Errorf("tendermint lcd address is not set"))
-		return
-	}
-
 	apiClient := api.NewClient(logger.GetLogger(), grpcConn, &api.ClientConfig{
 		ReqPerSecond:        int(cfg.RequestsPerSecond),
-		ReqPerSecondLCD:     int(cfg.RequestsPerSecondLCD),
 		TimeoutBlockCall:    cfg.TimeoutBlockCall,
 		TimeoutSearchTxCall: cfg.TimeoutTransactionCall,
-	}, cfg.TendermintLCDAddr, cfg.DataHubKey)
+	})
 
 	grpcServer := grpc.NewServer()
 	workerClient := client.NewIndexerClient(ctx, logger.GetLogger(), apiClient, uint64(cfg.MaximumHeightsToGet))


### PR DESCRIPTION
[notion](https://www.notion.so/figmentnetworks/b47c0f8b935741d8ac28717ddeea2038?v=5e4e1d3854094b788ae2b612329f27e8&p=dbbbba6b1e254424a5a9288f4b9408e8)


- remove `tendermint_lcd_addr`, `requests_per_second_lcd`, `datahub_key` from config

